### PR TITLE
英語のみで言語の単位を満たしたときの表記ミスを修正

### DIFF
--- a/app.js
+++ b/app.js
@@ -221,6 +221,7 @@ const foreign_calc = () => {
         if (English >= 12) {
             second_foreign_judge = true
             document.getElementById('result_foreignTotal').innerHTML = document.getElementById('result_foreignTotal').innerHTML = "<div class='table_tooltip'><p class='success'>0 <svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='currentColor' class='bi bi-chat-left-text' viewBox='0 0 16 16'><path d='M14 1a1 1 0 0 1 1 1v8a1 1 0 0 1-1 1H4.414A2 2 0 0 0 3 11.586l-2 2V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12.793a.5.5 0 0 0 .854.353l2.853-2.853A1 1 0 0 1 4.414 12H14a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z'/><path d='M3 3.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5zM3 6a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9A.5.5 0 0 1 3 6zm0 2.5a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1h-5a.5.5 0 0 1-.5-.5z'/></svg> </span></p><div class='description'>英語12単位で満たされています．</div></div>";
+            document.getElementById('result_second').textContent = 0
             log("英語12");
         } else if (English >= 8 && second_foreign_judge == true) {
             // 英語8単位以上かつ，第二言語1つを4単位以上とっているならば


### PR DESCRIPTION
英語を12単位 取得して言語の要件を満たした場合，
第二言語の不足単位を0にするよう修正．

https://ie.u-ryukyu.ac.jp/~e195765/TKG/
